### PR TITLE
Don't use multi-windows for operator-pending mode.

### DIFF
--- a/lua/pounce.lua
+++ b/lua/pounce.lua
@@ -52,7 +52,7 @@ local function match(needle_, haystack_)
 end
 
 function M.pounce()
-  local windows = M.config.multi_window and vim.api.nvim_tabpage_list_wins(0) or { vim.api.nvim_get_current_win() }
+  local windows = not string.find(vim.api.nvim_get_mode().mode, "o") and M.config.multi_window and vim.api.nvim_tabpage_list_wins(0) or { vim.api.nvim_get_current_win() }
   local ns = vim.api.nvim_create_namespace ""
 
   local input = ""


### PR DESCRIPTION
Regardless of the config setting, multi-window mode is not useful, and
potentially dangerous, when in operator-pending mode. A reasonable
alternative would be to accept an override in `opts` to disable the
feature for the single call, to be used in omaps.
