### PR TITLE
Add highlight for unmatched characters

### DIFF
--- a/doc/pounce.txt
+++ b/doc/pounce.txt
@@ -17,6 +17,7 @@ Commands~
 Highlights~
 
     * `PounceMatch`: Characters that match the fuzzy search pattern.
+    * `PounceUnmatched`: Characters that don't match the fuzzy search pattern.
     * `PounceGap`: Characters inside a match that are not part of the pattern.
     * `PounceAccept`: "Accept keys" that can be used to jump to the match.
     * `PounceAcceptBest`: Highlights the accept key for the best match.

--- a/lua/pounce.lua
+++ b/lua/pounce.lua
@@ -73,6 +73,17 @@ function M.pounce(opts)
       cursor_pos[2] + 1
     )
 
+    for _, win in ipairs(windows) do
+      local buf = vim.api.nvim_win_get_buf(win)
+      local win_info = vim.fn.getwininfo(win)[1]
+      vim.api.nvim_buf_set_extmark(buf, ns, win_info.topline - 1, 0, {
+        end_line = win_info.botline,
+        hl_group = "PounceUnmatched",
+        hl_eol = true,
+        priority = 65533,
+      })
+    end
+
     if input ~= "" then
       local hits = {}
       local current_win = vim.api.nvim_get_current_win()

--- a/plugin/pounce.vim
+++ b/plugin/pounce.vim
@@ -4,6 +4,7 @@ if !has("nvim")
 endif
 
 highlight default PounceMatch cterm=bold ctermfg=black ctermbg=green gui=bold guifg=#555555 guibg=#11dd11
+highlight default link PounceUnmatched None
 highlight default PounceGap cterm=bold ctermfg=black ctermbg=darkgreen gui=bold guifg=#555555 guibg=#00aa00
 highlight default PounceAccept cterm=bold ctermfg=black ctermbg=lightred gui=bold guifg=#111111 guibg=#de940b
 highlight default PounceAcceptBest cterm=bold ctermfg=black ctermbg=cyan gui=bold guifg=#111111 guibg=#03cafc


### PR DESCRIPTION
i really like this feature from hop or leap. so i decided to implement it in my new favorite jumping plugin :)

`PounceUnmatched` has no highlight by default