### PR TITLE
`<C-h>` to delete input characters

### DIFF
--- a/lua/pounce.lua
+++ b/lua/pounce.lua
@@ -193,7 +193,7 @@ function M.pounce(opts)
 
     if nr == 27 then -- escape
       break
-    elseif nr == "\x80kb" then -- backspace
+    elseif nr == "\x80kb" or nr == 8 then -- backspace or <C-h>
       input = input:sub(1, -2)
     else
       local ch = vim.fn.nr2char(nr)


### PR DESCRIPTION
Thank you for your nice plugin!
I want to delete input characters by `<C-h>` (like as [`c_CTRL-H`](https://neovim.io/doc/user/cmdline.html#c_CTRL-H)) because backspace key is a little far from my finger 😋 

![画面収録 2022-08-08 20 52 17](https://user-images.githubusercontent.com/8146876/183412323-9cdfc3bd-cbae-40e5-84d8-3b4f0e7f86c4.gif)
