### PR TITLE
Implement <C-u> to reset input

### DIFF
--- a/lua/pounce.lua
+++ b/lua/pounce.lua
@@ -213,6 +213,8 @@ function M.pounce(opts)
       break
     elseif nr == "\x80kb" or nr == 8 then -- backspace or <C-h>
       input = input:sub(1, -2)
+    elseif nr == 21 then -- <C-u>
+      input = ""
     else
       local ch = vim.fn.nr2char(nr)
       local accepted = accept_key_map[ch]


### PR DESCRIPTION
I just feel the need of having the ability to reset the whole input, especially when I typed too fast, I had to `<Esc>` and started a new Pounce search from the beginning (and spamming `<BS>` or `<C-h>` doesn't feel so right).