### PR TITLE
skip matching if no fzy positions found

### DIFF
--- a/lua/pounce/matcher.lua
+++ b/lua/pounce/matcher.lua
@@ -15,6 +15,10 @@ function M.match(needle_, haystack_)
 
     if fzy.has_match(needle, haystack, false) then
       local indices, score = fzy.positions(needle, haystack, false)
+      if #indices == 0 then
+        return
+      end
+
       local left_haystack = string.sub(haystack, 1, indices[1] - 1)
       local right_haystack = string.sub(haystack, indices[#indices] + 1, -1)
       assert(left_haystack:len() < haystack:len())


### PR DESCRIPTION
fix for https://github.com/rlane/pounce.nvim/issues/34

This occurs because `fzy.positions` checks for `MATCH_MAX_LENGTH` whereas `fzy.has_match` does not.