### PR TITLE
[Feature request] Auto select last match

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Here are the defaults:
 require'pounce'.setup{
   accept_keys = "JFKDLSAHGNUVRBYTMICEOXWPQZ",
   accept_best_key = "<enter>",
+  accept_on_last = false, -- if true, auto jumps to the last match
   multi_window = true,
   debug = false,
 }

--- a/lua/pounce.lua
+++ b/lua/pounce.lua
@@ -7,6 +7,7 @@ local M = {}
 local config = {
   accept_keys = "JFKDLSAHGNUVRBYTMICEOXWPQZ",
   accept_best_key = "<enter>",
+  accept_on_last = false,
   multi_window = true,
   debug = false,
 }
@@ -281,6 +282,16 @@ function M.pounce(opts, ns)
 
       -- Discard relatively low-scoring matches.
       hits = matcher.filter(hits)
+
+      -- accept match if only one remaining. only if `opts.accept_on_last == true`
+      if not opts.just_preview and opts.accept_on_last and #hits == 1 then
+        local hit = hits[1]
+        local accepted = { window = hit.window, position = { hit.line, hit.indices[1] - 1 } }
+        vim.cmd "normal! m'"
+        vim.api.nvim_win_set_cursor(accepted.window, accepted.position)
+        vim.api.nvim_set_current_win(accepted.window)
+        break
+      end
 
       table.sort(hits, function(a, b)
         return a.score > b.score


### PR DESCRIPTION
Hi @rlane. Thank you very much for the awesome plugin.

I would like to jump to the match automatically if the remaining number of matches is 1.

This PR adds an option `accept_on_last` which makes the cursor jump to the destination automatically when there is only 1 match left.

I made the default value to `false` so there would be no change in the default behavior.
I also added docs in README about this option.

Please let me know your thoughts about this.

Thanks ;)