### PR TITLE
fix typo in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ You can also use the lua api directly:
 ```lua
 local map = vim.keymap.set
 map("n", "s", function() require'pounce'.pounce { } end)
-map("n", "s", function() require'pounce'.pounce { do_repeat = true } end)
+map("n", "S", function() require'pounce'.pounce { do_repeat = true } end)
 map("x", "s", function() require'pounce'.pounce { } end)
 map("o", "gs", function() require'pounce'.pounce { } end)
 map("n", "S", function() require'pounce'.pounce { input = {reg="/"} } end)


### PR DESCRIPTION
Thank you for the wonderful plugin!
I found a typo in the README.md and have corrected it.

In vim, it was written as follows,
nmap **S** <cmd>PounceRepeat<CR>

However, in lua, it was written as follows, which was inconsistent.
map("n", **"s"**, function() require'pounce'.pounce { do_repeat = true } end)

I hope this small correction helps to further improve your great plugin!
Thank you!
