### PR TITLE
Add option to increase cmd height if zero

### DIFF
--- a/lua/pounce.lua
+++ b/lua/pounce.lua
@@ -9,6 +9,7 @@ local config = {
   accept_best_key = "<enter>",
   multi_window = true,
   debug = false,
+  increase_cmd_height_if_zero = true,
 }
 
 local default_hl = {
@@ -206,7 +207,7 @@ function M.pounce(opts, ns)
   local hl_prio = 65533
 
   local old_cmdheight = vim.o.cmdheight
-  if not opts.just_preview then
+  if not opts.just_preview and opts.increase_cmd_height_if_zero then
     if old_cmdheight == 0 then
       vim.o.cmdheight = 1
       vim.cmd "redraw"


### PR DESCRIPTION
As someone that uses `noice.nvim` with pop-up cmdline it can be annoying when the `cmdheight` increases then decreases moving the bottom statusline up-down when activating pounce, hence this tiny change that provides an option to disable this behavior.